### PR TITLE
[FEATURE] Add additional help and links to search results page

### DIFF
--- a/t3SphinxThemeRtd/static/searchtools.js
+++ b/t3SphinxThemeRtd/static/searchtools.js
@@ -503,14 +503,10 @@ var Search = {
         }
         var encodedQuery = Search.encodeHtml(query);
         var searchUrl1 = 'https://www.startpage.com/do/dsearch?query=site%3Adocs.typo3.org+' + encodeURI(encodedQuery);
-        var searchUrl2 = 'https://www.google.com/search?q=site%3Adocs.typo3.org+' + encodeURI(encodedQuery);
         Search.status.html(_( searchResultText
             + '<hr /><em>The search function only searches within the current manual ' + docTitle + '.</em>'
-            + '<br/> For a wider search, try '
-            + '<ul>'
-            + '<li><a href="' + searchUrl1 + '">startpage.com with site:docs.typo3.org ' + encodedQuery + '</a></li>'
-            + '<li><a href="' + searchUrl2 + '">google.com with site:docs.typo3.org ' + encodedQuery + '</a></li>'
-            + '</ul>'
+            + '<br/> For a wider search, try: '
+            + '<a href="' + searchUrl1 + '">startpage.com with site:docs.typo3.org ' + encodedQuery + '</a>'
         ));
 
         Search.status.fadeIn(500);

--- a/t3SphinxThemeRtd/static/searchtools.js
+++ b/t3SphinxThemeRtd/static/searchtools.js
@@ -509,7 +509,7 @@ var Search = {
             + '<br/> For a wider search, try '
             + '<ul>'
             + '<li><a href="' + searchUrl1 + '">startpage.com with site:docs.typo3.org ' + encodedQuery + '</a></li>'
-            + '<li><a href="' + searchUrl2 + '">google.com with site:docs.typo3.org' + encodedQuery + '</a></li>'
+            + '<li><a href="' + searchUrl2 + '">google.com with site:docs.typo3.org ' + encodedQuery + '</a></li>'
             + '</ul>'
         ));
 


### PR DESCRIPTION
- remove text about categories in search results page because it's
  misleading
- add information that search only searches in current manual
- add title of manual, if available
- add links to external search engines and pass (encoded) original
  query

Resolves: #84 

**before**
 
![before](https://user-images.githubusercontent.com/13206455/42421790-bdecf558-82db-11e8-968d-9adaf1f8624f.png)


**after**

![after2](https://user-images.githubusercontent.com/13206455/42432241-df17926a-8349-11e8-955d-613b64b2507a.png)

This will automatically generate the URL for the search engine [startpage.com](https://www.startpage.com), restricting it to docs.typo3.org and using the search terms the user entered.

This is the URL used in the screenshot:

https://www.startpage.com/do/dsearch?query=site%3Adocs.typo3.org+suggestwizard

It will also properly encode search terms. Will also work with more than one term:

https://www.startpage.com/do/dsearch?query=site%3Adocs.typo3.org+suggest+wizard