### PR TITLE
Change "Edit me on GitHub" to "Propose a change on GitHub"

### DIFF
--- a/t3SphinxThemeRtd/breadcrumbs.html
+++ b/t3SphinxThemeRtd/breadcrumbs.html
@@ -15,9 +15,9 @@
             {%- endif %}
 
             {%- if theme_path_to_documentation_dir %}
-                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a file change on GitHub</a>
+                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a change on GitHub</a>
             {%- else %}
-                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a file change on GitHub</a>
+                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a change on GitHub</a>
             {%- endif %}
 
           {%- elif display_github and builder == 'html' %}

--- a/t3SphinxThemeRtd/breadcrumbs.html
+++ b/t3SphinxThemeRtd/breadcrumbs.html
@@ -15,9 +15,9 @@
             {%- endif %}
 
             {%- if theme_path_to_documentation_dir %}
-                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Edit me on GitHub</a>
+                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a file change on GitHub</a>
             {%- else %}
-                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Edit me on GitHub</a>
+                <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Propose a file change on GitHub</a>
             {%- endif %}
 
           {%- elif display_github and builder == 'html' %}


### PR DESCRIPTION
From #typo3-documentation on the TYPO3 Slack:

> We discussed this at the brainstorming and contribution sessions yesterday, and it seems to non-developer users and possibly even more people that “Edit me on GitHub” already represents some kind of elevated permission state (e.g. “you already have the rights to directly edit”) which might hinder contributions due to an added weight of responsibility that might come to mind with direct editing.
>
> The new wording is based exactly on how GitHub is handling Pull Requests, where it also mentions it as “Propose change”.

I also quickly adjusted it and removed the specific mention of "file" from the button, this also might take away a bit of the developer-context to contribute!