### PR TITLE
Add link to docs workflow introduction below edit button

### DIFF
--- a/sass/_t3_addons.sass
+++ b/sass/_t3_addons.sass
@@ -26,9 +26,17 @@ h1, h2, h3, h4, h5, h6, legend
 #EditMeOnGitHub
   color: white
   background-color: $typo3-key-color
-  display: block
+  display: inline-block
   padding: 6px 10px
   border-radius: 15px
+
+.t3-contribution-text
+  margin-top: 0
+  text-align: center
+
+  > a:first-child
+    padding: 0
+
 
 input
   &[type="text"]

--- a/t3SphinxThemeRtd/breadcrumbs.html
+++ b/t3SphinxThemeRtd/breadcrumbs.html
@@ -16,8 +16,10 @@
 
             {%- if theme_path_to_documentation_dir %}
                 <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Edit me on GitHub</a>
+                <p class="t3-contribution-text"><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocsOfficial/Index.html">Learn more</a> about contributing</p>
             {%- else %}
                 <a id="EditMeOnGitHub" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank" class="fa fa-github"> Edit me on GitHub</a>
+                <p class="t3-contribution-text"><a href="https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocsOfficial/Index.html">Learn more</a> about contributing</p>
             {%- endif %}
 
           {%- elif display_github and builder == 'html' %}


### PR DESCRIPTION
This PR adds a small section of text "Learn more about contributing" including a link to the official guide here: https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocsOfficial/Index.html

Here's a screenshot on how everything looks currently with all proposed CSS and HTML changes _(It looks better with a wider button with more text, like in #124)_:
<img width="249" alt="Screenshot 2019-08-05 at 23 38 34" src="https://user-images.githubusercontent.com/1774242/62496907-aa559600-b7da-11e9-8540-4d39935ac235.png">


This PR doesn't include the compiled assets required for changes to be reflected and someone who is able to run the asset generation needs to do that, regardless of what Node or Ruby version I was running I always ran into following error:

```
Syntax error: Invalid CSS after "      webkit-image": expected ")", was ": -webkit- + $p..."
        on line 21 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/helpers/_linear-angle-parser.scss
        from line 10 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/_bourbon.scss
        from line 11 of sass/badge_only.sass
  Use --trace for backtrace.
Syntax error: Invalid CSS after "      webkit-image": expected ")", was ": -webkit- + $p..."
        on line 21 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/helpers/_linear-angle-parser.scss
        from line 10 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/_bourbon.scss
        from line 21 of sass/theme.sass
  Use --trace for backtrace.
Syntax error: Invalid CSS after "      webkit-image": expected ")", was ": -webkit- + $p..."
        on line 21 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/helpers/_linear-angle-parser.scss
        from line 10 of /Users/pixeldesu/Projects/t3SphinxThemeRtd/node_modules/bourbon/dist/_bourbon.scss
        from line 21 of sass/theme-no-fonts.sass
  Use --trace for backtrace.

```

This solves #120!